### PR TITLE
增加 docker 部署的支持（有2点和原有设计差异，间备注）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /app
 
 RUN uv pip install --system -r /app/requirements.txt
 
-CMD [ "python", "rsshub.py" ]
+CMD [ "python", "rsshub_sse.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-alpine
+
+RUN pip install uv
+
+COPY rsshub /app
+WORKDIR /app
+
+RUN uv pip install --system -r /app/requirements.txt
+
+CMD [ "python", "rsshub.py" ]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ source .venv/bin/activate  # Linux/macOS
 uv pip install -r requirements.txt
 ```
 
+## Docker
+
+推荐使用 docker 镜像来启动 mcp server
+
+`docker compose up -d`
+
+启动后配置SSE的服务如下：
+
+```json
+{
+    "mcpServers": {
+        "rsshub": {
+            "url": "http://localhost:8081/sse/",
+            "timeout": 60,
+        },
+    }
+}
+```
+
 ## 注意事项
 
 - 工具会自动尝试多个 RSSHub 实例，直到成功获取数据

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+name: mcp-rsshub-json
+
+services:
+  mcp-rsshub-json:
+    container_name: mcp-rsshub-json
+    # image: ghcr.io/upbit/mcp-rsshub-json:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8081:8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
-name: mcp-rsshub-json
+name: mcp-servers
 
 services:
-  mcp-rsshub-json:
-    container_name: mcp-rsshub-json
+  mcp-rsshub:
+    container_name: mcp-rsshub
     # image: ghcr.io/upbit/mcp-rsshub-json:latest
     build:
       context: .

--- a/rsshub/rsshub.py
+++ b/rsshub/rsshub.py
@@ -13,7 +13,7 @@ mcp = FastMCP("rsshub")
 
 # 添加 RSSHub 实例列表
 RSSHUB_INSTANCES = [
-    # "https://rsshub.app",
+    "https://rsshub.app",
     "https://rsshub.rssforever.com",
     "https://rsshub.feeded.xyz",
     "https://hub.slarker.me",
@@ -28,31 +28,29 @@ RSSHUB_INSTANCES = [
     "https://rsshub.ktachibana.party",
     "https://rsshub.woodland.cafe",
     "https://rsshub.aierliz.xyz",
-    "http://localhost:1200",
+    "http://localhost:1200"
 ]
-
 
 def convert_rsshub_url(url: str) -> str:
     """将 rsshub:// 格式的链接或标准 RSSHub URL 转换为所有可能的实例 URL"""
-    if url.startswith("rsshub://"):
+    if url.startswith('rsshub://'):
         path = url[9:]
         return [f"{instance}/{path}" for instance in RSSHUB_INSTANCES]
-
+    
     # 处理标准 RSSHub URL
     for instance in RSSHUB_INSTANCES:
         if url.startswith(instance):
             # 提取路径部分
-            path = url[len(instance) :].lstrip("/")
+            path = url[len(instance):].lstrip('/')
             # 为所有实例生成对应的 URL
             return [f"{inst}/{path}" for inst in RSSHUB_INSTANCES]
-
+    
     return [url]  # 非 RSSHub 格式的 URL 直接返回单个 URL 的列表
-
 
 @mcp.tool()
 async def rsshub_get_feed(url: str) -> Dict[str, Any]:
     """获取RSSHub的RSS源"""
-
+    
     # 确保参数是字符串类型
     if isinstance(url, (dict, str)):
         try:
@@ -61,8 +59,8 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
                 # 尝试解析JSON字符串
                 try:
                     parsed = json.loads(url)
-                    if isinstance(parsed, dict) and "url" in parsed:
-                        url = parsed["url"]
+                    if isinstance(parsed, dict) and 'url' in parsed:
+                        url = parsed['url']
                 except json.JSONDecodeError:
                     # 如果不是有效的JSON，直接使用原始字符串
                     pass
@@ -70,87 +68,87 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
             print(f"URL处理错误: {str(e)}")
             # 如果解析失败，保持原始URL不变
             pass
-
+    
     if not isinstance(url, str):
         raise ValueError(f"URL必须是字符串类型，当前类型: {type(url)}")
-
+    
     # 如果URL是bilibili这样的路径格式，自动添加rsshub://前缀
-    if not url.startswith(("http://", "https://", "rsshub://")):
+    if not url.startswith(('http://', 'https://', 'rsshub://')):
         url = f"rsshub://{url}"
-
+    
     # 转换 rsshub:// 格式的链接，获取所有可能的URL
     urls = convert_rsshub_url(url)
-
+    
     # 模拟真实浏览器的 User-Agent 列表
     user_agents = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
     ]
-
+    
     headers = {
         "User-Agent": random.choice(user_agents),
         "Accept": "application/rss+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
         "Accept-Encoding": "gzip, deflate, br",
-        "Connection": "keep-alive",
+        "Connection": "keep-alive"
     }
 
     last_error = None
-
+    
     # 遍历所有可能的URL，直到成功获取数据
     for current_url in urls:
         try:
             async with httpx.AsyncClient(
-                timeout=30.0, follow_redirects=True, verify=False
+                timeout=30.0,
+                follow_redirects=True,
+                verify=False
             ) as client:
                 response = await client.get(current_url, headers=headers)
                 response.raise_for_status()
-
+                
                 # 使用 feedparser 解析 RSS
                 feed = feedparser.parse(response.text)
-
-                if not feed.entries and not hasattr(feed, "feed"):
+                
+                if not feed.entries and not hasattr(feed, 'feed'):
                     raise Exception("无法解析RSS源")
 
                 # 获取 feed 元数据
                 feed_info = {
-                    "title": feed.feed.get("title"),
-                    "link": feed.feed.get("link"),
-                    "description": feed.feed.get("description"),
-                    "items": [],
+                    "title": feed.feed.get('title'),
+                    "link": feed.feed.get('link'),
+                    "description": feed.feed.get('description'),
+                    "items": []
                 }
 
                 # 处理每个条目
                 for entry in feed.entries:
                     # 清理 HTML 内容
-                    description = entry.get("description", "")
+                    description = entry.get('description', '')
                     if description:
-                        soup = BeautifulSoup(description, "html.parser")
-                        description = soup.get_text(separator=" ", strip=True)
+                        soup = BeautifulSoup(description, 'html.parser')
+                        description = soup.get_text(separator=' ', strip=True)
 
                     # 处理发布日期
                     pub_date = None
-                    if "published_parsed" in entry:
+                    if 'published_parsed' in entry:
                         try:
                             dt = datetime(*entry.published_parsed[:6])
                             pub_date = dt.astimezone(pytz.UTC).isoformat()
                         except Exception as e:
                             print(f"Date parse error: {str(e)}")
-                            pub_date = entry.get("published", "")
+                            pub_date = entry.get('published', '')
 
                     # 构建条目字典
                     feed_item = {
-                        "title": entry.get("title"),
+                        "title": entry.get('title'),
                         "description": description,
-                        "link": entry.get("link"),
-                        "guid": entry.get("id", entry.get("guid", entry.get("link"))),
+                        "link": entry.get('link'),
+                        "guid": entry.get('id', entry.get('guid', entry.get('link'))),
                         "pubDate": pub_date,
-                        "author": entry.get("author"),
-                        "category": [tag.term for tag in entry.get("tags", [])]
-                        if "tags" in entry
-                        else None,
+                        "author": entry.get('author'),
+                        "category": [tag.term for tag in entry.get('tags', [])] if 'tags' in entry else None
                     }
                     feed_info["items"].append(feed_item)
 
@@ -160,10 +158,9 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
             last_error = e
             print(f"尝试访问 {current_url} 失败: {str(e)}")
             continue  # 尝试下一个URL
-
+    
     # 如果所有URL都失败，抛出最后一个错误
     raise Exception(f"所有RSSHub实例均无法访问: {str(last_error)}")
 
-
 if __name__ == "__main__":
-    mcp.run(transport="sse")
+    mcp.run(transport='stdio')

--- a/rsshub/rsshub.py
+++ b/rsshub/rsshub.py
@@ -13,7 +13,7 @@ mcp = FastMCP("rsshub")
 
 # 添加 RSSHub 实例列表
 RSSHUB_INSTANCES = [
-    "https://rsshub.app",
+    # "https://rsshub.app",
     "https://rsshub.rssforever.com",
     "https://rsshub.feeded.xyz",
     "https://hub.slarker.me",
@@ -28,29 +28,31 @@ RSSHUB_INSTANCES = [
     "https://rsshub.ktachibana.party",
     "https://rsshub.woodland.cafe",
     "https://rsshub.aierliz.xyz",
-    "http://localhost:1200"
+    "http://localhost:1200",
 ]
+
 
 def convert_rsshub_url(url: str) -> str:
     """将 rsshub:// 格式的链接或标准 RSSHub URL 转换为所有可能的实例 URL"""
-    if url.startswith('rsshub://'):
+    if url.startswith("rsshub://"):
         path = url[9:]
         return [f"{instance}/{path}" for instance in RSSHUB_INSTANCES]
-    
+
     # 处理标准 RSSHub URL
     for instance in RSSHUB_INSTANCES:
         if url.startswith(instance):
             # 提取路径部分
-            path = url[len(instance):].lstrip('/')
+            path = url[len(instance) :].lstrip("/")
             # 为所有实例生成对应的 URL
             return [f"{inst}/{path}" for inst in RSSHUB_INSTANCES]
-    
+
     return [url]  # 非 RSSHub 格式的 URL 直接返回单个 URL 的列表
+
 
 @mcp.tool()
 async def rsshub_get_feed(url: str) -> Dict[str, Any]:
     """获取RSSHub的RSS源"""
-    
+
     # 确保参数是字符串类型
     if isinstance(url, (dict, str)):
         try:
@@ -59,8 +61,8 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
                 # 尝试解析JSON字符串
                 try:
                     parsed = json.loads(url)
-                    if isinstance(parsed, dict) and 'url' in parsed:
-                        url = parsed['url']
+                    if isinstance(parsed, dict) and "url" in parsed:
+                        url = parsed["url"]
                 except json.JSONDecodeError:
                     # 如果不是有效的JSON，直接使用原始字符串
                     pass
@@ -68,87 +70,87 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
             print(f"URL处理错误: {str(e)}")
             # 如果解析失败，保持原始URL不变
             pass
-    
+
     if not isinstance(url, str):
         raise ValueError(f"URL必须是字符串类型，当前类型: {type(url)}")
-    
+
     # 如果URL是bilibili这样的路径格式，自动添加rsshub://前缀
-    if not url.startswith(('http://', 'https://', 'rsshub://')):
+    if not url.startswith(("http://", "https://", "rsshub://")):
         url = f"rsshub://{url}"
-    
+
     # 转换 rsshub:// 格式的链接，获取所有可能的URL
     urls = convert_rsshub_url(url)
-    
+
     # 模拟真实浏览器的 User-Agent 列表
     user_agents = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
     ]
-    
+
     headers = {
         "User-Agent": random.choice(user_agents),
         "Accept": "application/rss+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
         "Accept-Encoding": "gzip, deflate, br",
-        "Connection": "keep-alive"
+        "Connection": "keep-alive",
     }
 
     last_error = None
-    
+
     # 遍历所有可能的URL，直到成功获取数据
     for current_url in urls:
         try:
             async with httpx.AsyncClient(
-                timeout=30.0,
-                follow_redirects=True,
-                verify=False
+                timeout=30.0, follow_redirects=True, verify=False
             ) as client:
                 response = await client.get(current_url, headers=headers)
                 response.raise_for_status()
-                
+
                 # 使用 feedparser 解析 RSS
                 feed = feedparser.parse(response.text)
-                
-                if not feed.entries and not hasattr(feed, 'feed'):
+
+                if not feed.entries and not hasattr(feed, "feed"):
                     raise Exception("无法解析RSS源")
 
                 # 获取 feed 元数据
                 feed_info = {
-                    "title": feed.feed.get('title'),
-                    "link": feed.feed.get('link'),
-                    "description": feed.feed.get('description'),
-                    "items": []
+                    "title": feed.feed.get("title"),
+                    "link": feed.feed.get("link"),
+                    "description": feed.feed.get("description"),
+                    "items": [],
                 }
 
                 # 处理每个条目
                 for entry in feed.entries:
                     # 清理 HTML 内容
-                    description = entry.get('description', '')
+                    description = entry.get("description", "")
                     if description:
-                        soup = BeautifulSoup(description, 'html.parser')
-                        description = soup.get_text(separator=' ', strip=True)
+                        soup = BeautifulSoup(description, "html.parser")
+                        description = soup.get_text(separator=" ", strip=True)
 
                     # 处理发布日期
                     pub_date = None
-                    if 'published_parsed' in entry:
+                    if "published_parsed" in entry:
                         try:
                             dt = datetime(*entry.published_parsed[:6])
                             pub_date = dt.astimezone(pytz.UTC).isoformat()
                         except Exception as e:
                             print(f"Date parse error: {str(e)}")
-                            pub_date = entry.get('published', '')
+                            pub_date = entry.get("published", "")
 
                     # 构建条目字典
                     feed_item = {
-                        "title": entry.get('title'),
+                        "title": entry.get("title"),
                         "description": description,
-                        "link": entry.get('link'),
-                        "guid": entry.get('id', entry.get('guid', entry.get('link'))),
+                        "link": entry.get("link"),
+                        "guid": entry.get("id", entry.get("guid", entry.get("link"))),
                         "pubDate": pub_date,
-                        "author": entry.get('author'),
-                        "category": [tag.term for tag in entry.get('tags', [])] if 'tags' in entry else None
+                        "author": entry.get("author"),
+                        "category": [tag.term for tag in entry.get("tags", [])]
+                        if "tags" in entry
+                        else None,
                     }
                     feed_info["items"].append(feed_item)
 
@@ -158,9 +160,10 @@ async def rsshub_get_feed(url: str) -> Dict[str, Any]:
             last_error = e
             print(f"尝试访问 {current_url} 失败: {str(e)}")
             continue  # 尝试下一个URL
-    
+
     # 如果所有URL都失败，抛出最后一个错误
     raise Exception(f"所有RSSHub实例均无法访问: {str(last_error)}")
 
+
 if __name__ == "__main__":
-    mcp.run(transport='stdio')
+    mcp.run(transport="sse")

--- a/rsshub/rsshub_sse.py
+++ b/rsshub/rsshub_sse.py
@@ -1,0 +1,23 @@
+from rsshub import *
+
+RSSHUB_INSTANCES = [
+    # "https://rsshub.app",
+    "https://rsshub.rssforever.com",
+    "https://rsshub.feeded.xyz",
+    "https://hub.slarker.me",
+    "https://rsshub.liumingye.cn",
+    "https://rsshub-instance.zeabur.app",
+    "https://rss.fatpandac.com",
+    "https://rsshub.pseudoyu.com",
+    "https://rsshub.friesport.ac.cn",
+    "https://rsshub.atgw.io",
+    "https://rsshub.rss.tips",
+    "https://rsshub.mubibai.com",
+    "https://rsshub.ktachibana.party",
+    "https://rsshub.woodland.cafe",
+    "https://rsshub.aierliz.xyz",
+    "http://localhost:1200",
+]
+
+if __name__ == "__main__":
+    mcp.run(transport="sse")


### PR DESCRIPTION
**新增内容**

1. 增加 Dockerfile 和 docker compose 的支持；README 增加相关介绍；
2. 增加 qwen_agent 调用 mcp server 的示例（问题`使用 rsshub 工具获取 rsshub://zaobao/realtime/world 的最新内容`，输出如下）

> ![image](https://github.com/user-attachments/assets/972bdd50-9628-45e9-8acd-687430b796ce)


**有2点和原有设计差异，可能需要review下**：

1. rsshub.py中，从stdio改成了sse输出（方便docker的端口映射，默认`8081`）
4. 我这边访问 "https://rsshub.app" 经常超时，备用站点比较多因此注释了这个